### PR TITLE
release: v3.1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@technote-space/fast-glob",
-  "version": "3.1.7",
+  "version": "3.1.8",
   "description": "It's a very fast and efficient glob library for Node.js",
   "author": {
     "name": "Denis Malinochkin",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@nodelib/fs.stat": "^2.0.3",
     "@nodelib/fs.walk": "^1.2.4",
-    "glob-parent": "^5.1.0",
+    "glob-parent": "^5.1.1",
     "merge2": "^1.3.0",
     "micromatch": "^4.0.2"
   },
@@ -51,7 +51,7 @@
     "@types/micromatch": "^4.0.1",
     "@types/minimist": "^1.2.0",
     "@types/mocha": "^7.0.2",
-    "@types/node": "^13.9.2",
+    "@types/node": "^13.9.3",
     "@types/rimraf": "^3.0.0",
     "@types/sinon": "^7.5.2",
     "compute-stdev": "^1.0.0",
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.2",
     "sinon": "^9.0.1",
     "tiny-glob": "^0.2.6",
-    "ts-node": "^8.7.0",
+    "ts-node": "^8.8.1",
     "typescript": "^3.8.3"
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,9 +32,9 @@
     source-map "^0.5.0"
 
 "@babel/generator@^7.9.0":
-  version "7.9.0"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.9.0.tgz#0f67adea4ec39dad6e63345f70eec33014d78c89"
-  integrity sha512-onl4Oy46oGCzymOXtKMQpI7VXtCbTSHK1kqBydZ6AmzuNcacEVqGk9tZtAS+48IA9IstZcDCgIg8hQKnb7suRw==
+  version "7.9.4"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.9.4.tgz#12441e90c3b3c4159cdecf312075bf1a8ce2dbce"
+  integrity sha512-rjP8ahaDy/ouhrvCoU1E5mqaitWrxwuNGU+dy1EpaoK48jZay4MdkskKGIMHLZNewg8sAsqpGSREJwP0zH3YQA==
   dependencies:
     "@babel/types" "^7.9.0"
     jsesc "^2.5.1"
@@ -140,9 +140,9 @@
     js-tokens "^4.0.0"
 
 "@babel/parser@^7.7.5", "@babel/parser@^7.8.6", "@babel/parser@^7.9.0":
-  version "7.9.2"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.9.2.tgz#4e767f424b479c514077544484d1f9bdba7f1158"
-  integrity sha512-2jyvKdoOS1aWAFL2rjJZmamyDDkPCx/AAz4/Wh1Dfxvw8qqnOvek/ZlHQ2noO/o8JpnXa/WiUUFOv48meBKkpA==
+  version "7.9.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.9.4.tgz#68a35e6b0319bbc014465be43828300113f2f2e8"
+  integrity sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA==
 
 "@babel/template@^7.7.4", "@babel/template@^7.8.3", "@babel/template@^7.8.6":
   version "7.8.6"
@@ -339,10 +339,10 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-7.0.2.tgz#b17f16cf933597e10d6d78eae3251e692ce8b0ce"
   integrity sha512-ZvO2tAcjmMi8V/5Z3JsyofMe3hasRcaw88cto5etSVMwVQfeivGAlEYmaQgceUSVYFofVjT+ioHsATjdWcFt1w==
 
-"@types/node@*", "@types/node@^13.9.2":
-  version "13.9.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.9.2.tgz#ace1880c03594cc3e80206d96847157d8e7fa349"
-  integrity sha512-bnoqK579sAYrQbp73wwglccjJ4sfRdKU7WNEZ5FW4K2U6Kc0/eZ5kvXG0JKsEKFB50zrFmfFt52/cvBbZa7eXg==
+"@types/node@*", "@types/node@^13.9.3":
+  version "13.9.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.9.3.tgz#6356df2647de9eac569f9a52eda3480fa9e70b4d"
+  integrity sha512-01s+ac4qerwd6RHD+mVbOEsraDHSgUaefQlEdBbUolnQFjKwCr7luvAlEwW1RFojh67u0z4OUTjPn9LEl4zIkA==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -363,39 +363,39 @@
   integrity sha512-T+m89VdXj/eidZyejvmoP9jivXgBDdkOSBVQjU9kF349NEx10QdPNGxHeZUaj1IlJ32/ewdyXJjnJxyxJroYwg==
 
 "@typescript-eslint/eslint-plugin@^2.13.0":
-  version "2.24.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.24.0.tgz#a86cf618c965a462cddf3601f594544b134d6d68"
-  integrity sha512-wJRBeaMeT7RLQ27UQkDFOu25MqFOBus8PtOa9KaT5ZuxC1kAsd7JEHqWt4YXuY9eancX0GK9C68i5OROnlIzBA==
+  version "2.25.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.25.0.tgz#0b60917332f20dcff54d0eb9be2a9e9f4c9fbd02"
+  integrity sha512-W2YyMtjmlrOjtXc+FtTelVs9OhuR6OlYc4XKIslJ8PUJOqgYYAPRJhAqkYRQo3G4sjvG8jSodsNycEn4W2gHUw==
   dependencies:
-    "@typescript-eslint/experimental-utils" "2.24.0"
-    eslint-utils "^1.4.3"
+    "@typescript-eslint/experimental-utils" "2.25.0"
     functional-red-black-tree "^1.0.1"
     regexpp "^3.0.0"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@2.24.0":
-  version "2.24.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.24.0.tgz#a5cb2ed89fedf8b59638dc83484eb0c8c35e1143"
-  integrity sha512-DXrwuXTdVh3ycNCMYmWhUzn/gfqu9N0VzNnahjiDJvcyhfBy4gb59ncVZVxdp5XzBC77dCncu0daQgOkbvPwBw==
+"@typescript-eslint/experimental-utils@2.25.0":
+  version "2.25.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.25.0.tgz#13691c4fe368bd377b1e5b1e4ad660b220bf7714"
+  integrity sha512-0IZ4ZR5QkFYbaJk+8eJ2kYeA+1tzOE1sBjbwwtSV85oNWYUBep+EyhlZ7DLUCyhMUGuJpcCCFL0fDtYAP1zMZw==
   dependencies:
     "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "2.24.0"
+    "@typescript-eslint/typescript-estree" "2.25.0"
     eslint-scope "^5.0.0"
+    eslint-utils "^2.0.0"
 
 "@typescript-eslint/parser@^2.13.0":
-  version "2.24.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.24.0.tgz#2cf0eae6e6dd44d162486ad949c126b887f11eb8"
-  integrity sha512-H2Y7uacwSSg8IbVxdYExSI3T7uM1DzmOn2COGtCahCC3g8YtM1xYAPi2MAHyfPs61VKxP/J/UiSctcRgw4G8aw==
+  version "2.25.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.25.0.tgz#abfb3d999084824d9a756d9b9c0f36fba03adb76"
+  integrity sha512-mccBLaBSpNVgp191CP5W+8U1crTyXsRziWliCqzj02kpxdjKMvFHGJbK33NroquH3zB/gZ8H511HEsJBa2fNEg==
   dependencies:
     "@types/eslint-visitor-keys" "^1.0.0"
-    "@typescript-eslint/experimental-utils" "2.24.0"
-    "@typescript-eslint/typescript-estree" "2.24.0"
+    "@typescript-eslint/experimental-utils" "2.25.0"
+    "@typescript-eslint/typescript-estree" "2.25.0"
     eslint-visitor-keys "^1.1.0"
 
-"@typescript-eslint/typescript-estree@2.24.0":
-  version "2.24.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.24.0.tgz#38bbc8bb479790d2f324797ffbcdb346d897c62a"
-  integrity sha512-RJ0yMe5owMSix55qX7Mi9V6z2FDuuDpN6eR5fzRJrp+8in9UF41IGNQHbg5aMK4/PjVaEQksLvz0IA8n+Mr/FA==
+"@typescript-eslint/typescript-estree@2.25.0":
+  version "2.25.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.25.0.tgz#b790497556734b7476fa7dd3fa539955a5c79e2c"
+  integrity sha512-VUksmx5lDxSi6GfmwSK7SSoIKSw9anukWWNitQPqt58LuYrKalzsgeuignbqnB+rK/xxGlSsCy8lYnwFfB6YJg==
   dependencies:
     debug "^4.1.1"
     eslint-visitor-keys "^1.1.0"
@@ -855,9 +855,9 @@ error-ex@^1.2.0, error-ex@^1.3.1:
     is-arrayish "^0.2.1"
 
 es-abstract@^1.17.0, es-abstract@^1.17.0-next.1:
-  version "1.17.4"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.4.tgz#e3aedf19706b20e7c2594c35fc0d57605a79e184"
-  integrity sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==
+  version "1.17.5"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.5.tgz#d8c9d1d66c8981fb9200e2251d799eee92774ae9"
+  integrity sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==
   dependencies:
     es-to-primitive "^1.2.1"
     function-bind "^1.1.1"
@@ -1023,6 +1023,13 @@ eslint-utils@^1.4.2, eslint-utils@^1.4.3:
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
+eslint-utils@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.0.0.tgz#7be1cc70f27a72a76cd14aa698bcabed6890e1cd"
+  integrity sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==
+  dependencies:
+    eslint-visitor-keys "^1.1.0"
+
 eslint-visitor-keys@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
@@ -1086,11 +1093,11 @@ esprima@^4.0.0:
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
 esquery@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.1.0.tgz#c5c0b66f383e7656404f86b31334d72524eddb48"
-  integrity sha512-MxYW9xKmROWF672KqjO75sszsA8Mxhw06YFeS5VHlB98KDHbOSurm3ArsjO60Eaf3QmGMCP1yn+0JQkNLo/97Q==
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.2.0.tgz#a010a519c0288f2530b3404124bfb5f02e9797fe"
+  integrity sha512-weltsSqdeWIX9G2qQZz7KlTRJdkkOCTPgLYJUz1Hacf48R4YOwGPHO3+ORfWedqJKbq5WQmsgK90n+pFLIKt/Q==
   dependencies:
-    estraverse "^4.0.0"
+    estraverse "^5.0.0"
 
 esrecurse@^4.1.0:
   version "4.2.1"
@@ -1099,10 +1106,15 @@ esrecurse@^4.1.0:
   dependencies:
     estraverse "^4.1.0"
 
-estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1:
+estraverse@^4.1.0, estraverse@^4.1.1:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
+
+estraverse@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.0.0.tgz#ac81750b482c11cca26e4b07e83ed8f75fbcdc22"
+  integrity sha512-j3acdrMzqrxmJTNj5dbr1YbjacrYgAxVMeF0gK16E3j494mOe7xygM/ZLIguEQ0ETwAg2hlJCtHRGav+y0Ny5A==
 
 esutils@^2.0.2:
   version "2.0.3"
@@ -1290,10 +1302,10 @@ get-stream@^5.0.0:
   dependencies:
     pump "^3.0.0"
 
-glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@~5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.0.tgz#5f4c1d1e748d30cd73ad2944b3577a81b081e8c2"
-  integrity sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==
+glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@^5.1.1, glob-parent@~5.1.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
+  integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
   dependencies:
     is-glob "^4.0.1"
 
@@ -1837,10 +1849,17 @@ minimist@^1.2.5:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
-mkdirp@0.5.3, mkdirp@^0.5.1:
+mkdirp@0.5.3:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.3.tgz#5a514b7179259287952881e94410ec5465659f8c"
   integrity sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==
+  dependencies:
+    minimist "^1.2.5"
+
+mkdirp@^0.5.1:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.4.tgz#fd01504a6797ec5c9be81ff43d204961ed64a512"
+  integrity sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==
   dependencies:
     minimist "^1.2.5"
 
@@ -2701,10 +2720,10 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-ts-node@^8.7.0:
-  version "8.7.0"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.7.0.tgz#266186947596bef9f3a034687595b30e31b20976"
-  integrity sha512-s659CsHrsxaRVDEleuOkGvbsA0rWHtszUNEt1r0CgAFN5ZZTQtDzpsluS7W5pOGJIa1xZE8R/zK4dEs+ldFezg==
+ts-node@^8.8.1:
+  version "8.8.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.8.1.tgz#7c4d3e9ed33aa703b64b28d7f9d194768be5064d"
+  integrity sha512-10DE9ONho06QORKAaCBpPiFCdW+tZJuY/84tyypGtl6r+/C7Asq0dhqbRZURuUlLQtZxxDvT8eoj8cGW0ha6Bg==
   dependencies:
     arg "^4.1.0"
     diff "^4.0.1"


### PR DESCRIPTION
<!-- START pr-commits   please keep comment here to allow auto update -->
## Changes


* chore: update npm dependencies (f5874e31aa98b542a12b87ef1f148a6709353981)

<!-- END pr-commits   please keep comment here to allow auto update -->

## Base PullRequest

default branch (https://github.com/technote-space/fast-glob/tree/master)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v1/node_modules/npm-check-updates/bin
```



</details>
<details>
<summary><em>ncu -u --packageFile package.json</em></summary>

```Shell
Upgrading /home/runner/work/fast-glob/fast-glob/package.json

 glob-parent   ^5.1.0  →   ^5.1.1 
 @types/node  ^13.9.2  →  ^13.9.3 
 ts-node       ^8.7.0  →   ^8.8.1 

Run npm install to install new versions.
```



</details>
<details>
<summary><em>yarn install</em></summary>

```Shell
yarn install v1.22.4
[1/5] Validating package.json...
[2/5] Resolving packages...
[3/5] Fetching packages...
info fsevents@2.1.2: The platform "linux" is incompatible with this module.
info "fsevents@2.1.2" is an optional dependency and failed compatibility check. Excluding it from installation.
[4/5] Linking dependencies...
[5/5] Building fresh packages...
success Saved lockfile.
Done in 10.86s.
```

### stderr:

```Shell
warning " > @istanbuljs/nyc-config-typescript@1.0.1" has unmet peer dependency "source-map-support@*".
```

</details>
<details>
<summary><em>yarn upgrade</em></summary>

```Shell
yarn upgrade v1.22.4
[1/5] Validating package.json...
[2/5] Resolving packages...
[3/5] Fetching packages...
info fsevents@2.1.2: The platform "linux" is incompatible with this module.
info "fsevents@2.1.2" is an optional dependency and failed compatibility check. Excluding it from installation.
[4/5] Linking dependencies...
[5/5] Rebuilding all packages...
success Saved lockfile.
success Saved 279 new dependencies.
info Direct dependencies
├─ @istanbuljs/nyc-config-typescript@1.0.1
├─ @nodelib/fs.macchiato@1.0.2
├─ @nodelib/fs.stat@2.0.3
├─ @nodelib/fs.walk@1.2.4
├─ @types/compute-stdev@1.0.0
├─ @types/easy-table@0.0.32
├─ @types/glob-parent@5.1.0
├─ @types/glob@7.1.1
├─ @types/merge2@1.3.0
├─ @types/micromatch@4.0.1
├─ @types/minimist@1.2.0
├─ @types/mocha@7.0.2
├─ @types/rimraf@3.0.0
├─ @types/sinon@7.5.2
├─ compute-stdev@1.0.0
├─ easy-table@1.1.1
├─ eslint-config-mrmlnc@1.1.1
├─ eslint@6.8.0
├─ execa@4.0.0
├─ fast-glob@3.2.2
├─ glob-parent@5.1.1
├─ glob@7.1.6
├─ mocha@7.1.1
├─ nyc@15.0.0
├─ rimraf@3.0.2
├─ sinon@9.0.1
├─ tiny-glob@0.2.6
├─ ts-node@8.8.1
└─ typescript@3.8.3
info All dependencies
├─ @babel/core@7.9.0
├─ @babel/helper-function-name@7.8.3
├─ @babel/helper-get-function-arity@7.8.3
├─ @babel/helper-member-expression-to-functions@7.8.3
├─ @babel/helper-module-imports@7.8.3
├─ @babel/helper-module-transforms@7.9.0
├─ @babel/helper-optimise-call-expression@7.8.3
├─ @babel/helper-replace-supers@7.8.6
├─ @babel/helper-simple-access@7.8.3
├─ @babel/helpers@7.9.2
├─ @babel/highlight@7.9.0
├─ @babel/parser@7.9.4
├─ @babel/traverse@7.9.0
├─ @istanbuljs/load-nyc-config@1.0.0
├─ @istanbuljs/nyc-config-typescript@1.0.1
├─ @nodelib/fs.macchiato@1.0.2
├─ @nodelib/fs.scandir@2.1.3
├─ @nodelib/fs.stat@2.0.3
├─ @nodelib/fs.walk@1.2.4
├─ @sinonjs/formatio@5.0.1
├─ @sinonjs/samsam@5.0.3
├─ @sinonjs/text-encoding@0.7.1
├─ @types/braces@3.0.0
├─ @types/color-name@1.1.1
├─ @types/compute-stdev@1.0.0
├─ @types/easy-table@0.0.32
├─ @types/eslint-visitor-keys@1.0.0
├─ @types/events@3.0.0
├─ @types/glob-parent@5.1.0
├─ @types/glob@7.1.1
├─ @types/json-schema@7.0.4
├─ @types/merge2@1.3.0
├─ @types/micromatch@4.0.1
├─ @types/minimatch@3.0.3
├─ @types/minimist@1.2.0
├─ @types/mocha@7.0.2
├─ @types/normalize-package-data@2.4.0
├─ @types/rimraf@3.0.0
├─ @types/sinon@7.5.2
├─ @typescript-eslint/eslint-plugin@2.25.0
├─ @typescript-eslint/parser@2.25.0
├─ acorn-jsx@5.2.0
├─ acorn@7.1.1
├─ aggregate-error@3.0.1
├─ ajv@6.12.0
├─ ansi-colors@3.2.3
├─ ansi-escapes@4.3.1
├─ anymatch@3.1.1
├─ append-transform@2.0.0
├─ archy@1.0.0
├─ arg@4.1.3
├─ argparse@1.0.10
├─ array-includes@3.1.1
├─ array.prototype.flat@1.2.3
├─ astral-regex@1.0.0
├─ balanced-match@1.0.0
├─ binary-extensions@2.0.0
├─ brace-expansion@1.1.11
├─ braces@3.0.2
├─ browser-stdout@1.3.1
├─ buffer-from@1.1.1
├─ caching-transform@4.0.0
├─ callsites@3.1.0
├─ camelcase@5.3.1
├─ chalk@2.4.2
├─ chardet@0.7.0
├─ chokidar@3.3.0
├─ ci-info@2.0.0
├─ clean-regexp@1.0.0
├─ clean-stack@2.2.0
├─ cli-cursor@3.1.0
├─ cli-width@2.2.0
├─ cliui@5.0.0
├─ clone@1.0.4
├─ color-convert@1.9.3
├─ color-name@1.1.3
├─ commondir@1.0.1
├─ compute-stdev@1.0.0
├─ concat-map@0.0.1
├─ contains-path@0.1.0
├─ deep-is@0.1.3
├─ default-require-extensions@3.0.0
├─ defaults@1.0.3
├─ diff@4.0.2
├─ doctrine@3.0.0
├─ easy-table@1.1.1
├─ emoji-regex@7.0.3
├─ end-of-stream@1.4.4
├─ error-ex@1.3.2
├─ es-to-primitive@1.2.1
├─ es6-error@4.1.1
├─ escape-string-regexp@1.0.5
├─ eslint-ast-utils@1.1.0
├─ eslint-config-mrmlnc@1.1.1
├─ eslint-config-xo@0.27.2
├─ eslint-import-resolver-node@0.3.3
├─ eslint-module-utils@2.5.2
├─ eslint-plugin-es@2.0.0
├─ eslint-plugin-import@2.19.1
├─ eslint-plugin-mocha@6.2.2
├─ eslint-plugin-node@10.0.0
├─ eslint-plugin-unicorn@15.0.1
├─ eslint-template-visitor@1.1.0
├─ eslint@6.8.0
├─ espree@6.2.1
├─ esprima@4.0.1
├─ esquery@1.2.0
├─ esrecurse@4.2.1
├─ estraverse@4.3.0
├─ execa@4.0.0
├─ external-editor@3.1.0
├─ fast-deep-equal@3.1.1
├─ fast-glob@3.2.2
├─ fast-json-stable-stringify@2.1.0
├─ fast-levenshtein@2.0.6
├─ fastq@1.6.1
├─ figures@3.2.0
├─ file-entry-cache@5.0.1
├─ fill-range@7.0.1
├─ find-cache-dir@3.3.1
├─ find-up@4.1.0
├─ flat-cache@2.0.1
├─ flat@4.1.0
├─ flatted@2.0.1
├─ fromentries@1.2.0
├─ gensync@1.0.0-beta.1
├─ get-stream@5.1.0
├─ glob-parent@5.1.1
├─ glob@7.1.6
├─ globals@12.4.0
├─ globalyzer@0.1.4
├─ globrex@0.1.2
├─ graceful-fs@4.2.3
├─ growl@1.10.5
├─ he@1.2.0
├─ hosted-git-info@2.8.8
├─ html-escaper@2.0.1
├─ human-signals@1.1.1
├─ iconv-lite@0.4.24
├─ ignore@4.0.6
├─ import-fresh@3.2.1
├─ import-modules@2.0.0
├─ indent-string@4.0.0
├─ inquirer@7.1.0
├─ is-arrayish@0.2.1
├─ is-binary-path@2.1.0
├─ is-buffer@2.0.4
├─ is-callable@1.1.5
├─ is-date-object@1.0.2
├─ is-extglob@2.1.1
├─ is-glob@4.0.1
├─ is-number@7.0.0
├─ is-promise@2.1.0
├─ is-regex@1.0.5
├─ is-string@1.0.5
├─ is-symbol@1.0.3
├─ is-windows@1.0.2
├─ isarray@0.0.1
├─ istanbul-lib-hook@3.0.0
├─ istanbul-lib-instrument@4.0.1
├─ istanbul-lib-processinfo@2.0.2
├─ istanbul-lib-source-maps@4.0.0
├─ istanbul-reports@3.0.0
├─ js-tokens@4.0.0
├─ jsesc@2.5.2
├─ json-parse-better-errors@1.0.2
├─ json-schema-traverse@0.4.1
├─ json-stable-stringify-without-jsonify@1.0.1
├─ json5@2.1.2
├─ just-extend@4.1.0
├─ levn@0.3.0
├─ lines-and-columns@1.1.6
├─ load-json-file@2.0.0
├─ locate-path@5.0.0
├─ lodash.camelcase@4.3.0
├─ lodash.defaultsdeep@4.6.1
├─ lodash.flattendeep@4.4.0
├─ lodash.kebabcase@4.1.1
├─ lodash.snakecase@4.1.1
├─ lodash.upperfirst@4.3.1
├─ lodash.zip@4.2.0
├─ log-symbols@3.0.0
├─ make-error@1.3.6
├─ merge-stream@2.0.0
├─ mimic-fn@2.1.0
├─ mocha@7.1.1
├─ multimap@1.1.0
├─ mute-stream@0.0.8
├─ natural-compare@1.4.0
├─ nice-try@1.0.5
├─ nise@4.0.3
├─ node-environment-flags@1.0.6
├─ node-preload@0.2.1
├─ normalize-package-data@2.5.0
├─ normalize-path@3.0.0
├─ npm-run-path@4.0.1
├─ nyc@15.0.0
├─ object-inspect@1.7.0
├─ object-keys@1.1.1
├─ object.assign@4.1.0
├─ object.getownpropertydescriptors@2.1.0
├─ object.values@1.1.1
├─ optionator@0.8.3
├─ os-tmpdir@1.0.2
├─ p-limit@2.2.2
├─ p-locate@4.1.0
├─ p-try@2.2.0
├─ package-hash@4.0.0
├─ parent-module@1.0.1
├─ parse-json@5.0.0
├─ path-key@3.1.1
├─ path-parse@1.0.6
├─ path-to-regexp@1.8.0
├─ path-type@2.0.0
├─ pkg-dir@4.2.0
├─ progress@2.0.3
├─ pump@3.0.0
├─ punycode@2.1.1
├─ ramda@0.26.1
├─ read-pkg-up@2.0.0
├─ read-pkg@2.0.0
├─ readdirp@3.2.0
├─ regexp-tree@0.1.21
├─ release-zalgo@1.0.0
├─ reserved-words@0.1.2
├─ resolve@1.15.1
├─ restore-cursor@3.1.0
├─ reusify@1.0.4
├─ rimraf@3.0.2
├─ run-async@2.4.0
├─ run-parallel@1.1.9
├─ rxjs@6.5.4
├─ safe-buffer@5.1.2
├─ safe-regex@2.1.1
├─ safer-buffer@2.1.2
├─ semver@6.3.0
├─ shebang-command@2.0.0
├─ shebang-regex@3.0.0
├─ sinon@9.0.1
├─ slice-ansi@2.1.0
├─ source-map-support@0.5.16
├─ spawn-wrap@2.0.0
├─ spdx-correct@3.1.0
├─ spdx-exceptions@2.2.0
├─ sprintf-js@1.0.3
├─ string.prototype.trimleft@2.1.1
├─ string.prototype.trimright@2.1.1
├─ strip-ansi@5.2.0
├─ strip-bom@4.0.0
├─ strip-final-newline@2.0.0
├─ strip-json-comments@2.0.1
├─ table@5.4.6
├─ test-exclude@6.0.0
├─ text-table@0.2.0
├─ through@2.3.8
├─ tiny-glob@0.2.6
├─ tmp@0.0.33
├─ to-fast-properties@2.0.0
├─ to-regex-range@5.0.1
├─ ts-node@8.8.1
├─ tslib@1.11.1
├─ type-detect@4.0.8
├─ type-fest@0.8.1
├─ typedarray-to-buffer@3.1.5
├─ typescript@3.8.3
├─ uri-js@4.2.2
├─ v8-compile-cache@2.1.0
├─ validate-npm-package-license@3.0.4
├─ wcwidth@1.0.1
├─ which@1.3.1
├─ wide-align@1.1.3
├─ word-wrap@1.2.3
├─ wrap-ansi@5.1.0
├─ write-file-atomic@3.0.3
├─ write@1.0.3
├─ yargs-parser@13.1.2
├─ yargs-unparser@1.6.0
├─ yargs@13.3.2
└─ yn@3.1.1
Done in 4.98s.
```

### stderr:

```Shell
warning eslint > mkdirp@0.5.4: Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)
warning eslint > file-entry-cache > flat-cache > write > mkdirp@0.5.4: Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)
warning mocha > mkdirp@0.5.3: Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)
warning " > @istanbuljs/nyc-config-typescript@1.0.1" has unmet peer dependency "source-map-support@*".
```

</details>
<details>
<summary><em>yarn audit</em></summary>

```Shell
yarn audit v1.22.4
0 vulnerabilities found - Packages audited: 1562
Done in 0.60s.
```



</details>

</details>

## Changed files
<details>
<summary>Changed 2 files: </summary>

- package.json
- yarn.lock

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)